### PR TITLE
Demo: use the `input` event instead of `keyup` where possible

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -53,7 +53,7 @@ var isInit = false;
 
 var colors = ['red', 'green', 'blue', 'purple', '#E67A00'];
 
-input.onkeyup = function() {
+var inputHandler = function() {
 	isInit && findAndReplaceDOMText.revert();
 	warning.style.display = 'none';
 	if (input.value) {
@@ -89,6 +89,13 @@ input.onkeyup = function() {
 			warning.style.display = 'inline';
 		}
 	}
+};
+
+// http://mathiasbynens.be/notes/oninput
+input.onkeyup = inputHandler;
+input.oninput = function() {
+	input.onkeyup = null;
+	inputHandler();
 };
 
 // Initial replacement to make words different sizes


### PR DESCRIPTION
This feels much faster, as the app doesn’t have to wait for `keyup`
to fire. Also, this means the app will now update the results when
you enter text without using the keyboard (e.g. a copy-paste using
the mouse, by dragging text in, or by dictating text, perhaps).

`keyup` is still used as the fallback event in case `input` isn’t
supported. More info: http://mathiasbynens.be/notes/oninput
