### PR TITLE
issue with HTML5 tags in IE 7/8

### DIFF
--- a/src/findAndReplaceDOMText.js
+++ b/src/findAndReplaceDOMText.js
@@ -179,8 +179,13 @@ window.findAndReplaceDOMText = (function() {
     if (typeof nodeName != 'function') {
       var stencilNode = nodeName.nodeType ? nodeName : document.createElement(nodeName);
       makeReplacementNode = function(fill) {
-        var el = stencilNode.cloneNode(false);
-        fill && el.appendChild(document.createTextNode(fill));
+        var clone = document.createElement('div'),
+            el;
+        clone.innerHTML = stencilNode.outerHTML;
+        el = clone.firstChild;
+        if(fill) {
+          el.appendChild(document.createTextNode(fill));
+        }
         return el;
       };
     } else {


### PR DESCRIPTION
If we want to use an HTML5 tag (like `<mark>`) as a wrapping node, the result will be broken in IE 7/8 due to  `cloneNode()` inside the `_genReplacer` function. IE has a buggy interpretation of this method and returns `<:mark>` instead (even with html5shim script enabled) - see http://bugs.jquery.com/ticket/6485 as as ref.

The bugs affects both ways of passing a node into the findAndReplaceDOMText function - as a node name and as a stenilNode.

The solution is to clone the node manually, like here http://pastie.org/935834

Pull request attached
