### PR TITLE
Support for capture groups

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -107,3 +107,35 @@ test('Custom replacement function - correct ordering', function() {
 	});
 	equal(nCalled, 3);
 });
+
+test('Capture groups', function() {
+
+	var text = 'TEST TESThello TESThello TESThello';
+	var d = document.createElement('div');
+
+	d.innerHTML = text;
+	findAndReplaceDOMText(/(TEST)hello/, d, 'x', 1);
+	htmlEqual(d.innerHTML, 'TEST <x>TEST</x>hello TESThello TESTHello');
+
+	d.innerHTML = text;
+	findAndReplaceDOMText(/(TEST)hello/g, d, 'x', 1);
+	htmlEqual(d.innerHTML, 'TEST <x>TEST</x>hello <x>TEST</x>hello <x>TEST</x>hello');
+
+	d.innerHTML = text;
+	findAndReplaceDOMText(/\s(TEST)(hello)/g, d, 'x', 2);
+	htmlEqual(d.innerHTML, 'TEST TEST<x>hello</x> TEST<x>hello</x> TEST<x>hello</x>');
+});
+
+test('Word boundaries', function() {
+
+	var text = 'a go matching at test wordat at';
+	var d = document.createElement('div');
+
+	d.innerHTML = text;
+	findAndReplaceDOMText(/\bat\b/, d, 'x');
+	htmlEqual(d.innerHTML, 'a go matching <x>at</x> test wordat at');
+
+	d.innerHTML = text;
+	findAndReplaceDOMText(/\bat\b/g, d, 'x');
+	htmlEqual(d.innerHTML, 'a go matching <x>at</x> test wordat <x>at</x>');
+});


### PR DESCRIPTION
Hi there. 

Background: I've been experimenting with finding and replacing Unicode words in the DOM. Traditionally one would use the word boundary metacharacter (\b) to match words, but that only works for ASCII characters, so I've created a regular expression that matches Unicode words but it requires the use of capture groups.

Solution: I've modified this script slightly to support capture groups.  I've added an additional argument that specifies which capture group to use in the match. This allows you to do something like:

``` javascript
findAndReplaceDOMText(/(TEST)hello/g, d, 'x', 1);
```

.. where it will match 'TESThello' but it will only replace 'TEST'. 

I've had to drop using regex.lastIndex as that doesn't fit when using capture groups. Instead I'm using match.index and determining the index of the capture group within the match. **NOTE:** This also fixes a bug when running non-greedy regexes. Previously you were using indexOf to find the index of a match:

``` javascript
m = text.match(regex);
index = text.indexOf(m[0]);
```

... that will break if using a word boundary in your regex, with the following example: /\bat\b/ : 'matching at'

I've added tests for both the capture groups and word boundaries non-greedy matches.

Please let me know what you think of this change. 
