### PR TITLE
Fixes a bug when using IE8 where the dom tree gets extra block elements ...

### DIFF
--- a/src/findAndReplaceDOMText.js
+++ b/src/findAndReplaceDOMText.js
@@ -238,7 +238,7 @@ window.findAndReplaceDOMText = (function() {
           var pnode = el.parentNode;
           pnode.insertBefore(el.firstChild, el);
           pnode.removeChild(el);
-          pnode.normalize();
+          setTimeout(pnode.normalize,0);
         });
         return el;
       } else {
@@ -268,7 +268,7 @@ window.findAndReplaceDOMText = (function() {
             var pnode = el.parentNode;
             pnode.insertBefore(el.firstChild, el);
             pnode.removeChild(el);
-            pnode.normalize();
+            setTimeout(pnode.normalize,0);
           }
         });
         return elB;


### PR DESCRIPTION
The p-element got a child p-elements, which is not allowed, and the markup got corrupted.

To reproduce: (use native IE8, not IE9 in IE8 mode)

Go to http://jquery-spellchecker.badsyntax.co/ckeditor.html

Place the cursor between "great explorer" and "of the truth" in the paragraph. Hit enter.

Press spellchecker (ABC-button on the top of the editor).

Spellcheck the second  paragraph (starting with 'of the truth'... Correct Noo, consequencses's and painful. 

At either "consequencses's" or "painful", the normalize function will create an extra paragraph when normalizing the p-element.
