### PR TITLE
Delete unused parameter "matchIndex"

### DIFF
--- a/src/findAndReplaceDOMText.js
+++ b/src/findAndReplaceDOMText.js
@@ -68,7 +68,7 @@
 					m.index += m[0].indexOf(cg);
 					m[0] = cg;
 				}
-		 
+
 				m.endIndex = m.index + m[0].length;
 				m.startIndex = m.index;
 				m.index = mi;
@@ -85,9 +85,9 @@
 		return true;
 	}
 
-	/** 
+	/**
 	 * findAndReplaceDOMText
-	 * 
+	 *
 	 * Locates matches and replaces with replacementNode
 	 *
 	 * @param {Node} node Element or Text node to search within
@@ -236,7 +236,7 @@
 			if (!match[0]) {
 				throw new Error('findAndReplaceDOMText cannot handle zero-length matches');
 			}
-	 
+
 			match.endIndex = characterOffset + match.index + match[0].length;
 			match.startIndex = characterOffset + match.index;
 			match.index = matchIndex;
@@ -304,10 +304,10 @@
 				return txt;
 
 			}
-			
+
 		},
 
-		/** 
+		/**
 		 * Steps through the target node, looking for matches, and
 		 * calling replaceFn when a match is found.
 		 */
@@ -379,7 +379,7 @@
 					curNode = this.replaceMatch(match, startPortion, innerPortions, endPortion);
 
 					// processMatches has to return the node that replaced the endNode
-					// and then we step back so we can continue from the end of the 
+					// and then we step back so we can continue from the end of the
 					// match:
 
 					atIndex -= (endPortion.node.data.length - endPortion.endIndexInNode);
@@ -437,7 +437,7 @@
 			this.reverts = [];
 		},
 
-		prepareReplacementString: function(string, portion, match, matchIndex) {
+		prepareReplacementString: function(string, portion, match) {
 			var portionMode = this.options.portionMode;
 			if (
 				portionMode === PORTION_MODE_FIRST &&
@@ -474,7 +474,7 @@
 			return string.substring(portion.indexInMatch, portion.indexInMatch + portion.text.length);
 		},
 
-		getPortionReplacementNode: function(portion, match, matchIndex) {
+		getPortionReplacementNode: function(portion, match) {
 
 			var replacement = this.options.replace || '$&';
 			var wrapper = this.options.wrap;
@@ -487,7 +487,7 @@
 			}
 
 			if (typeof replacement == 'function') {
-				replacement = replacement(portion, match, matchIndex);
+				replacement = replacement(portion, match);
 				if (replacement && replacement.nodeType) {
 					return replacement;
 				}
@@ -498,7 +498,7 @@
 
 			replacement = doc.createTextNode(
 				this.prepareReplacementString(
-					replacement, portion, match, matchIndex
+					replacement, portion, match
 				)
 			);
 


### PR DESCRIPTION
The parameter `matchIndex` is never used in `prepareReplacementString`.

The function `getPortionReplacementNode` forwards it to the user's `replace` function but gets never called itself with this argument set, so it'd be always undefined and thus can safely be deleted.
Besides that it wasn't mentioned in the docs anyway.