### PR TITLE
Add a wrapClass option if using the wrap functionality

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ The `options` object includes:
   * <code>$`</code> to represent everything to the left of the match.
   * `$'` to represent everything to the right of the match.
  * **wrap** *optional* (`String | Node`): A string representing the node-name of an element that will be wrapped around matches (e.g. `span` or `em`). Or a Node (i.e. a stencil node) that we will clone for each match portion.
- * **wrapClass** *optional* (`String`): A string representing the class name to be assigned to the wrapping element (e.g. <span class="myClass">found text</span>).
+ * **wrapClass** *optional* (`String`): A string representing the class name to be assigned to the wrapping element (e.g. <span class="myClass">found text</span>).  If the wrap: option is not specified, then this option is ignored.
  * **portionMode** *optional* (`String`, one of `"retain"` or `"first"`): Indicates whether to re-use existing node boundaries when replacing a match with text (i.e. the default, `"retain"`), or whether to instead place the entire replacement in the first-found match portion's node. *Most of the time you'll want the default*.
  * **filterElements** *optional* (`Function`): A function to be called on every element encountered by `findAndReplaceDOMText`. If the function returns false the element will be altogether ignored.
  * **forceContext** *optional* (`Function | Boolean`): A boolean or a boolean-returning function that'll be called on every element to determine if it should be considered as its own matching context. See below under [*Contexts*](#user-content-contexts) for more info.

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,50 @@ findAndReplaceDOMText(document.getElementById('container'), {
 </div>
 ```
 
+#### The `wrap` Option
+
+If you pass a string to the `wrap` option, every matching text segment will be wrapped in that element.  If you also specify the `wrapClass` option, the wrapping element will be assigned that class after it is created.  This is useful for attaching various styles from your css.
+
+E.g.
+
+*Input HTML*
+
+```html
+<div id="container">
+  Explaining how to wrap text in elements with and without classes assigned.
+</div>
+```
+
+*JS*
+
+```js
+findAndReplaceDOMText(document.getElementById('container'), {
+ find: 'without',
+ wrap: 'em'
+});
+findAndReplaceDOMText(document.getElementById('container'), {
+ find: 'with ',
+ wrap: 'em',
+ wrapClass: 'shiny'
+});
+```
+
+*CSS*
+
+```css
+.shiny {
+ background-color: yellow;
+}
+```
+
+*Output HTML*
+
+```html
+<div id="container">
+  Explaining how to wrap text in elements <em class="shiny">with </em>and <em>without</em> classes assigned.
+</div>
+```
+
 #### The instance
 
 Calling `findAndReplaceDOMText` returns an instance of an internal Finder constructor -- the API on the object is limited, at the moment, to reverting:

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,7 @@ The `options` object includes:
   * <code>$`</code> to represent everything to the left of the match.
   * `$'` to represent everything to the right of the match.
  * **wrap** *optional* (`String | Node`): A string representing the node-name of an element that will be wrapped around matches (e.g. `span` or `em`). Or a Node (i.e. a stencil node) that we will clone for each match portion.
+ * **wrapClass** *optional* (`String`): A string representing the class name to be assigned to the wrapping element (e.g. <span class="myClass">found text</span>).
  * **portionMode** *optional* (`String`, one of `"retain"` or `"first"`): Indicates whether to re-use existing node boundaries when replacing a match with text (i.e. the default, `"retain"`), or whether to instead place the entire replacement in the first-found match portion's node. *Most of the time you'll want the default*.
  * **filterElements** *optional* (`Function`): A function to be called on every element encountered by `findAndReplaceDOMText`. If the function returns false the element will be altogether ignored.
  * **forceContext** *optional* (`Function | Boolean`): A boolean or a boolean-returning function that'll be called on every element to determine if it should be considered as its own matching context. See below under [*Contexts*](#user-content-contexts) for more info.

--- a/src/findAndReplaceDOMText.js
+++ b/src/findAndReplaceDOMText.js
@@ -498,7 +498,7 @@
 
 			var el = typeof wrapper == 'string' ? doc.createElement(wrapper) : wrapper;
 
- 			if (wrapperClass) {
+ 			if (wrapperClass && el !== undefined) {
 				el.className = wrapperClass;
 			}
 

--- a/src/findAndReplaceDOMText.js
+++ b/src/findAndReplaceDOMText.js
@@ -498,7 +498,7 @@
 
 			var el = typeof wrapper == 'string' ? doc.createElement(wrapper) : wrapper;
 
- 			if (wrapperClass && el !== undefined) {
+ 			if (el && wrapperClass) {
 				el.className = wrapperClass;
 			}
 

--- a/src/findAndReplaceDOMText.js
+++ b/src/findAndReplaceDOMText.js
@@ -93,6 +93,7 @@
 	 * @param {Node} node Element or Text node to search within
 	 * @param {RegExp} options.find The regular expression to match
 	 * @param {String|Element} [options.wrap] A NodeName, or a Node to clone
+	 * @param {String} [options.wrapClass] A classname to append to the wrapping element
 	 * @param {String|Function} [options.replace='$&'] What to replace each match with
 	 * @param {Function} [options.filterElements] A Function to be called to check whether to
 	 *	process an element. (returning true = process element,
@@ -478,6 +479,7 @@
 
 			var replacement = this.options.replace || '$&';
 			var wrapper = this.options.wrap;
+			var wrapperClass = this.options.wrapClass;
 
 			if (wrapper && wrapper.nodeType) {
 				// Wrapper has been provided as a stencil-node for us to clone:
@@ -495,6 +497,10 @@
 			}
 
 			var el = typeof wrapper == 'string' ? doc.createElement(wrapper) : wrapper;
+
+ 			if (wrapperClass) {
+				el.className = wrapperClass;
+			}
 
 			replacement = doc.createTextNode(
 				this.prepareReplacementString(


### PR DESCRIPTION
I found in most cases when I was wrapping a match in a new element, I usually wanted to add a class to it so I could apply style via CSS instead of relying on the ability to change style with HTML.

I added a new optional option to specify a class that it will assign to the element it wraps around your matches.  It will do no harm if it is used but no wrap option is specified - it just silently gets ignored.

Also added a wrap section to the readme.